### PR TITLE
Increases the clarity of installation instructions and fixes build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,32 @@
 Zendesk Unity3D Plugin
 ======================
 
-This is a Unity plugin that wraps the iOS and Android Zendesk SDKs.
+This is a Unity plugin that wraps the iOS and Android Zendesk Support SDKs.
 
 ## Requirements
 
-- OSX or Linux operating system (The plugin is not supported on Windows)
-- Unity 5.0+
-- Xcode 8.0+ (if building for iOS)
-- Android SDK with the latest support repository and libraries installed. (Required to build the plugin, even if you are just using iOS)
+- Unity 5.x
+
+### OS requirements
+
+The Android build script, `./android-plugin/build.gradle`, requires the `zip` command which is commonly
+distributed on Linux and Unix based systems, including Mac OS.
+
+`zip.exe` is not distributed on Windows machines and must be [installed](http://gnuwin32.sourceforge.net/packages/zip.htm) and added to the PATH. 
+
+Alternatively, the 7zip command line application, `7za.exe`, can be used to perform the same task. More details are in the `stripCssFromAndroidSdk` task in `./android-plugin/build.gradle`.
+
+### iOS requirements
+
+- Xcode 8.0+
+- Android requirements also have to be met, even if only building the iOS plugin.
+
+### Android requirements
+
+Most requirements will be downloaded automatically. You will have to ensure that some components are up to date in the Android SDK Manager.
+
+- Android SDK Build-tools 24.0.0 
+- Latest version of Android Support Repository
 
 ## Basics
 
@@ -43,9 +61,11 @@ This is a Unity plugin that wraps the iOS and Android Zendesk SDKs.
     }
     ```
     
-4. Android conflicts
+4. Android manifest
 
+    * [MUST DO] One of the `<provider>` elements must be uncommented for the plugin to build correctly. See the documentation in `/Assets/Plugins/Android/AndroidManifest.xml`
     * You may already have a file at `/Assets/Plugins/Android/AndroidManifest.xml`. If so, you will have to manually merge the items of that manifest with the one we supply in our plugin.  Specifically, your `<application>` tag must have the `android:theme="@style/UnityTheme"` attribute, and your `UnityPlayerActivity` (or derived class) `<activity>` entry must have `<meta-data android:name="unityplayer.ForwardNativeEventsToDalvik" android:value="true" />` as a child tag.
+    
 
 ## App Configuration and Zendesk App Interfaces
 
@@ -181,7 +201,7 @@ Custom Help Center articles are styled with CSS that can be specified in the fol
 
 On Android, this file must be edited before you create the plugin with `./gradlew build`
 
-`/sdk_unity_plugin/android-plugin/src/main/res/assets/help_center_article_style.css`
+`/sdk_unity_plugin/android-plugin/src/main/assets/help_center_article_style.css`
 
 ## String and Localization Customization
 

--- a/android-plugin/build.gradle
+++ b/android-plugin/build.gradle
@@ -101,7 +101,20 @@ task stripCssFromAndroidSdk(type:Exec) {
     // ignoreExitValue true
 
     workingDir "$rootProject.buildDir/unity-plugin/Plugins/Android"
+
+    // This will work on Unix based systems with bash and zip available
     commandLine 'bash', '-c', 'zip -d sdk-[0-9].[0-9].[0-9].[0-9].aar assets/help_center_article_style.css'
+
+    /*
+        On Windows we don't have zip.exe out of the box, so you will have to install zip.exe or
+        7za.exe as per README.md and then do something like this instead of the commandLine above
+     */
+
+    // zip.exe
+    // commandLine 'zip.exe', '-d', 'sdk-1.7.2.1', 'assets/help_center_article_style.css'
+
+    // 7za.exe
+    // commandLine '7za.exe', 'd', 'sdk-1.7.2.1', 'assets/help_center_article_style.css'
 
     standardOutput = new ByteArrayOutputStream()
 

--- a/android-plugin/plugin-dependencies/AndroidManifest.xml
+++ b/android-plugin/plugin-dependencies/AndroidManifest.xml
@@ -30,8 +30,8 @@
         -->
 
         <!--
-        	In Unity 5.5b, when using the gradle build system,  applicationId is merged correctly in the
-        	belvedere library, which handles all image picking, storage, and retrieval in the SDK.
+            In Unity 5.5b+, when using the gradle build system,  applicationId is merged correctly in the
+            Belvedere library, which handles all image picking, storage, and retrieval in the SDK.
 
             {applicationId} is not merged correctly when this Manifest is processed, so you cannot use the {applicationId}
             placeholder. Instead, uncomment out the following provider, and replace APPLICATION_ID with your applicationId.
@@ -54,7 +54,7 @@
         -->
 
         <!--
-        	In unity 5.x, when using the standard build system, no placeholder expansion support is available. Belvedere requires
+        	In unity 5.x+, when using the standard build system, no placeholder expansion support is available. Belvedere requires
         	placeholder support to configure itself automatically, so you will have to override it's provider with the one below
         -->
         <!--

--- a/build.gradle
+++ b/build.gradle
@@ -12,4 +12,5 @@ task build << {
     }
 }
 
+clean.dependsOn("android-plugin:clean", "ios-plugin:clean")
 build.dependsOn("clean", "android-plugin:assemble", "ios-plugin:build")


### PR DESCRIPTION
### Changes

* Make it more clear about which provider to use in the AndroidManifest.xml
* Fix an issue where the android plugin would not be generated if a zip of the repository was downloaded
* Expand the README with more requirements

### Reviewers
@brendan-fahy @baz8080 @schlan @ndobri @oarrabi @tecknut @StevenDiviney @RonanMcH

### FYI
@KevinLambe @mathewcropper 

### Risks
- Low: no code changes and only one change to build process which should only make the build order more explicit.

