### PR TITLE
Adds a known issue on API 15 when building with internal build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,4 +239,5 @@ https://developer.zendesk.com/embeddables/docs/android/localize_text
 1. When creating a ticket using Rate My App on Android, the description of the issue is used for the subject line of the ticket.
 2. On request creation on Android, rotating the screen during sending appears to cancel the ticket. The progress dialog will disappear and the ticket form will regain focus.
 However, the ticket will still be successfully created, and will be present in the user's ticket list, though it will be missing any attachments added before the rotation.
-3. Unity 3D fails to detect the Android SDK correctly when Android SDK Tools 25.3.1 is installed. Tracked on [code.google.com](https://code.google.com/p/android/issues/detail?id=235455). 
+3. Unity 3D fails to detect the Android SDK correctly when Android SDK Tools 25.3.1 is installed. Tracked on [code.google.com](https://code.google.com/p/android/issues/detail?id=235455).
+4. The SDK can crash when deployed onto Android 4.0.3 devices. This occurs when your application is built with the `Internal (default)` build system. Building with gradle will fix this issue.


### PR DESCRIPTION
### Changes

Adds a known issue about the SDK crashing when built for API 15 when using the `default (internal)` build system.

### Reviewers
@brendan-fahy @baz8080 @schlan @ndobri @oarrabi @tecknut @StevenDiviney @RonanMcH

### References
- https://github.com/zendesk/sdk_unity_plugin/issues/24

### Risks
- None
