### PR TITLE
Bring iOS and Android attachment handling in line with each other

### DIFF
--- a/ios-plugin/src/ZendeskProviderUpload.m
+++ b/ios-plugin/src/ZendeskProviderUpload.m
@@ -16,13 +16,8 @@ void _zendeskUploadProviderUploadAttachment(char * gameObjectName, char * callba
         [contentTypeHolder rangeOfString:@"txt" options:NSCaseInsensitiveSearch].location != NSNotFound) {
         attachmentData = [GetStringParam(attachment) dataUsingEncoding:NSUTF8StringEncoding];
     }
-    else if ([contentTypeHolder rangeOfString:@"image" options:NSCaseInsensitiveSearch].location != NSNotFound ||
-             [contentTypeHolder rangeOfString:@"img" options:NSCaseInsensitiveSearch].location != NSNotFound) {
-        attachmentData = ZDKBase64DataFromString(GetStringParam(attachment));
-    }
     else {
-      NSLog(@"Warning: Upload type not recognized (%@), handling attachment as string", contentTypeHolder);
-      attachmentData = [GetStringParam(attachment) dataUsingEncoding:NSUTF8StringEncoding];
+        attachmentData = ZDKBase64DataFromString(GetStringParam(attachment));
     }
     
     ZDKDefCallback(ZDKUploadResponse*, [ZendeskJSON ZDKUploadResponseToJSON:result], "didUploadProviderUploadAttachment")


### PR DESCRIPTION
This is a potential fix for https://github.com/zendesk/sdk_unity_plugin/issues/29
The Android and iOS implementations were treating different content types differently, resulting in the problem uploading zip archives on iOS as described in the issue. I haven't tested this at all yet, but wanted to put up this up as a potential fix. 

### Changes
* Refactor iOS ZendeskProviderUpload.m to match logic of Android UploadProvider.java

### Reviewers
@baz8080 @schlan @oarrabi @tecknut @StevenDiviney @RonanMcH

### FYI

### References
- [UploadProvider.java](https://github.com/zendesk/sdk_unity_plugin/blob/master/android-plugin/src/main/java/com/zendesk/unity/providers/UploadProvider.java#L43-L47)
- [The Github issue](https://github.com/zendesk/sdk_unity_plugin/issues/29)

### Risks
- Medium: it's a change to the code that processes iOS attachments, so has potential to break attachment uploading on iOS.
