### PR TITLE
[BrokenWindow] Expose ShowRequestList method on iOS and Android

### DIFF
--- a/android-plugin/src/main/java/com/zendesk/unity/ZDK_Plugin.java
+++ b/android-plugin/src/main/java/com/zendesk/unity/ZDK_Plugin.java
@@ -19,6 +19,7 @@ import com.zendesk.sdk.model.helpcenter.Article;
 import com.zendesk.sdk.model.request.CustomField;
 import com.zendesk.sdk.network.impl.UserAgentHeaderUtil;
 import com.zendesk.sdk.network.impl.ZendeskConfig;
+import com.zendesk.sdk.requests.RequestActivity;
 import com.zendesk.sdk.support.ContactUsButtonVisibility;
 import com.zendesk.sdk.support.SupportActivity;
 import com.zendesk.sdk.support.ViewArticleActivity;
@@ -277,6 +278,17 @@ public class ZDK_Plugin extends UnityComponent {
                             }
                         }
                 ));
+            }
+        });
+    }
+
+    public void showRequestList() {
+        if(!checkInitialized())
+            return;
+
+        getActivity().runOnUiThread(new Runnable() {
+            public void run() {
+                RequestActivity.startActivity(getActivity(), null);
             }
         });
     }

--- a/ios-plugin/src/ZendeskRequests.m
+++ b/ios-plugin/src/ZendeskRequests.m
@@ -34,3 +34,7 @@ void _zendeskRequestsConfigureZDKRequests(char* requestSubject, char* tags[], in
 void _zendeskRequestsShowRequestCreation() {
     [ZDKRequests presentRequestCreationWithViewController:UnityGetGLViewController()];
 }
+
+void _zendeskRequestsShowRequestList() {
+    [ZDKRequests presentRequestListWithViewController:UnityGetGLViewController()];
+}

--- a/sample/ZendeskTester.cs
+++ b/sample/ZendeskTester.cs
@@ -161,6 +161,10 @@ public class ZendeskTester: MonoBehaviour
 			ZendeskSDK.ZDKRequests.ShowRequestCreationWithConfig (config);
 		}
 
+		if (GUILayout.Button ("Show Request List", buttonWidth)) {
+        	ZendeskSDK.ZDKRequests.ShowRequestList ();
+        }
+
 		if (GUILayout.Button ("Show Rate My App", buttonWidth)) {
 			ZendeskSDK.ZDKRMA.ShowAlways ();
 		}

--- a/unity-src/scripts/ZDKRequests.cs
+++ b/unity-src/scripts/ZDKRequests.cs
@@ -63,6 +63,13 @@ namespace ZendeskSDK {
 			instance().Do("showRequestCreation");
 		}
 
+		/// <summary>
+		/// Displays the request list screen.
+		/// </summary>
+		public static void ShowRequestList() {
+		    instance().Do("showRequestList");
+		}
+
 		public static void ShowRequestCreationWithConfig(ZendeskSDK.ZDKRequestCreationConfig config) {
 
 			if (config != null) {
@@ -82,6 +89,8 @@ namespace ZendeskSDK {
 		private static extern void _zendeskRequestsShowRequestCreation();
 		[DllImport("__Internal")]
 		private static extern void _zendeskRequestsConfigureZDKRequests(string requestSubject, string[] tags, int tagLength, string additionalInfo);
+		[DllImport("__Internal")]
+		private static extern void _zendeskRequestsShowRequestList();
 		#endif
 	}
 }


### PR DESCRIPTION
### Changes
* Expose ShowRequestList method on iOS and Android for showing request list directly, without opening the Help Center. 

### Reviewers
@brendan-fahy @baz8080 @schlan @oarrabi @tecknut @StevenDiviney @RonanMcH

### FYI

### References
- [Issue 39](https://github.com/zendesk/sdk_unity_plugin/issues/39)

### Risks
- Low
