### PR TITLE
Update Android SDK to 1.10.1.1

### DIFF
--- a/android-plugin/build.gradle
+++ b/android-plugin/build.gradle
@@ -47,7 +47,7 @@ dependencies {
      * The dependencies of the SDK artifact will be copied to the output directory in the packagePlugin
      * task.
      */
-    compile group: 'com.zendesk', name: 'sdk', version: '1.10.0.1'
+    compile group: 'com.zendesk', name: 'sdk', version: '1.10.1.1'
 }
 
 task packagePlugin <<  {


### PR DESCRIPTION
### Changes

Updates native Android SDK to 1.10.1.1 to bring in the fixes for voting controls, and fab control. See https://developer.zendesk.com/embeddables/docs/android/version_information#release-notes for full details


### Reviewers
@brendan-fahy @baz8080 @schlan @oarrabi @tecknut @StevenDiviney @RonanMcH
                                                                   
### FYI
@szymon-kazmierczak 

### References
-

### Risks
- Low | Medium | None
