### PR TITLE
Fix section filter being ignored

### DIFF
--- a/android-plugin/src/main/java/com/zendesk/unity/ZDK_Plugin.java
+++ b/android-plugin/src/main/java/com/zendesk/unity/ZDK_Plugin.java
@@ -176,10 +176,15 @@ public class ZDK_Plugin extends UnityComponent {
                 .withCategoriesCollapsed(collapseCategories)
                 .withContactUsButtonVisibility(visibility)
                 .withLabelNames(labelNames)
-                .withArticlesForSectionIds(sectionIds)
-                .withArticlesForCategoryIds(categoryIds)
                 .withArticleVoting(articleVoting);
 
+        if (sectionIds != null && sectionIds.length > 0) {
+            builder.withArticlesForSectionIds(sectionIds);
+        }
+
+        if (categoryIds != null && categoryIds.length > 0) {
+            builder.withArticlesForCategoryIds(categoryIds);
+        }
 
         if (StringUtils.hasLength(additionalInfo) || StringUtils.hasLength(requestSubject) || CollectionUtils.isNotEmpty(tags)) {
 


### PR DESCRIPTION
The `withArticlesForCategoryIds` and `withArticlesForSectionIds`  methods are exclusive. Calling one of them resets all changes from the other. In this case calling `withArticlesForCategoryIds` after `withArticlesForSectionIds` was preventing the section filter from being set. Even passing a null value will reset changes made by the other.

### Reviewers
@zendesk/adventure @zendesk/two-brothers

### FYI
@zendesk/adventure-qa

### References
-

### Risks
- Low
