### PR TITLE
Enable disable voting article view

### DIFF
--- a/android-plugin/src/main/java/com/zendesk/unity/ZDK_Plugin.java
+++ b/android-plugin/src/main/java/com/zendesk/unity/ZDK_Plugin.java
@@ -50,7 +50,9 @@ public class ZDK_Plugin extends UnityComponent {
     
     public static ZDK_Plugin _instance;
     public static Object instance(){
-        _instance = new ZDK_Plugin();
+        if (_instance == null) {
+            _instance = new ZDK_Plugin();
+        }
         return _instance;
     }
 

--- a/android-plugin/src/main/java/com/zendesk/unity/ZDK_Plugin.java
+++ b/android-plugin/src/main/java/com/zendesk/unity/ZDK_Plugin.java
@@ -44,6 +44,9 @@ public class ZDK_Plugin extends UnityComponent {
     private static final int CONTACT_US_BUTTON_VISIBILITY_OFF = 0;
     private static final int CONTACT_US_BUTTON_VISIBILITY_ARTICLE_LIST_ONLY = 1;
     private static final int CONTACT_US_BUTTON_VISIBILITY_ARTICLE_LIST_ARTICLE_VIEW = 2;
+
+    // Original behavior was to have article voting enabled
+    private boolean _articleVotingEnabled = true;
     
     public static ZDK_Plugin _instance;
     public static Object instance(){
@@ -124,6 +127,9 @@ public class ZDK_Plugin extends UnityComponent {
         }
     }
 
+    public void setArticleVotingEnabled(boolean enabled) {
+        _articleVotingEnabled = enabled;
+    }
 
     // ##### ##### ##### ##### ##### ##### ##### #####
     // ZDKLogger
@@ -231,7 +237,12 @@ public class ZDK_Plugin extends UnityComponent {
         provider.getArticle(idLong, new ZendeskCallback<Article>() {
             @Override
             public void onSuccess(Article article) {
-                ViewArticleActivity.startActivity(getActivity(), article);
+                ViewArticleActivity.startActivity(
+                        getActivity(),
+                        article,
+                        true, // By default enable add ticket button, might allow customization later
+                        null, // TODO: add further customization here
+                        _articleVotingEnabled);
             }
 
             @Override


### PR DESCRIPTION
I noticed that when you show an Article directly on iOS with c# `ZDKConfig.SetArticleVotingEnabled` only C# was working while Android was crashing silently. So I added an implementation to Android.
Further notes added to specific lines.

### Reviewers
@zendesk/adventure @zendesk/two-brothers

### FYI
@zendesk/adventure-qa

### References
-

### Risks
- Low
