### PR TITLE
Fix get ticket form is overflow issue

### DIFF
--- a/android-plugin/src/main/java/com/zendesk/unity/providers/RequestProvider.java
+++ b/android-plugin/src/main/java/com/zendesk/unity/providers/RequestProvider.java
@@ -88,7 +88,7 @@ public class RequestProvider extends UnityComponent {
                 new ZendeskUnityCallback<Comment>(gameObjectName, callbackId, "didRequestProviderAddCommentWithAttachments"));
     }
 
-    public void getTicketFormWithIds(final String gameObjectName, String callbackId, int[] ticketFormsIds, int formsCount){
+    public void getTicketFormWithIds(final String gameObjectName, String callbackId, long[] ticketFormsIds, int formsCount){
         
         Long[] result = new Long[formsCount];
         for (int i = 0; i < formsCount; i++) {

--- a/ios-plugin/src/ZendeskProviderRequest.m
+++ b/ios-plugin/src/ZendeskProviderRequest.m
@@ -65,13 +65,13 @@ void _zendeskRequestProviderAddComment(char * gameObjectName, char * callbackId,
               withCallback:callback];
 }
 
-void _zendeskRequestProviderGetTicketFormWithIds(char * gameObjectName, char * callbackId, int ticketFormsIds[], int formsCount) {
+void _zendeskRequestProviderGetTicketFormWithIds(char * gameObjectName, char * callbackId, int64_t ticketFormsIds[], int formsCount) {
     ZDKRequestProvider *provider = [ZDKRequestProvider new];
     ZDKDefCallback(NSArray<ZDKTicketForm*>*, [result toJSONString], "didRequestProviderGetTicketFormWithIds")
 
     NSMutableArray *formIds = @[].mutableCopy;
     for (int i = 0 ; i < formsCount ; i ++) {
-        [formIds addObject:[NSNumber numberWithInt:ticketFormsIds[i]]];
+        [formIds addObject:[NSNumber numberWithLongLong:ticketFormsIds[i]]];
     }
 
     [provider getTicketFormWithIds:formIds callback:callback];

--- a/unity-src/scripts/ZDKRequestProvider.cs
+++ b/unity-src/scripts/ZDKRequestProvider.cs
@@ -145,9 +145,9 @@ namespace ZendeskSDK {
 		/// </summary>
 		/// <param name="ticketForms">List of ticket form ids to get.</param>
 		/// <param name="callback">Callback that will deliver a List of Ticket Forms.</param>
-		public static void GetTicketForms(int[] ticketForms, Action<ArrayList,ZDKError> callback) {
+		public static void GetTicketForms(long[] ticketForms, Action<ArrayList,ZDKError> callback) {
 			if (ticketForms == null)
-				ticketForms = new int[0];
+				ticketForms = new long[0];
 			instance().Call("getTicketFormWithIds", callback, ticketForms, ticketForms.Length);
 		}
 
@@ -184,7 +184,7 @@ namespace ZendeskSDK {
 		[DllImport("__Internal")]
 		private static extern void _zendeskRequestProviderAddCommentWithAttachments(string gameObjectName, string callbackId, string comment, string requestId, string[] attachments, int attachmentsLength);
 		[DllImport("__Internal")]
-		private static extern void _zendeskRequestProviderGetTicketFormWithIds(string gameObjectName, string callbackId, int[] ticketFormsIds, int formsCount);
+		private static extern void _zendeskRequestProviderGetTicketFormWithIds(string gameObjectName, string callbackId, long[] ticketFormsIds, int formsCount);
 		[DllImport("__Internal")]
 		private static extern void _zendeskRequestProviderGetUpdatesForDevice(string gameObjectName, string callbackId);
 		[DllImport("__Internal")]


### PR DESCRIPTION
### Changes
I needed to create custom forms to allow users fill additional required information. Hence, I started using the request provider, but it was not working. The ticket form ids were expected to be integers but actual ids overflow this data type, so I have refactored the plugin to support long ticket form ids and thus fixing the issue.

### Reviewers
@zendesk/adventure @zendesk/two-brothers

### FYI
@zendesk/adventure-qa

### References
-

### Risks
- Medium
